### PR TITLE
feat/speed up polyline

### DIFF
--- a/src/mtr_node.py
+++ b/src/mtr_node.py
@@ -175,7 +175,8 @@ class MTRNode(Node):
             break_distance=break_distance,
             center_offset=center_offset,
         )
-
+        self._batch_polylines = None
+        self._batch_polylines_mask = None
         self._label_ids = [AgentLabel.from_str(label).value for label in labels]
 
         cfg = Config.from_file(model_config_path)
@@ -448,9 +449,13 @@ class MTRNode(Node):
         Returns:
 
         """
+        if self._batch_polylines is None or self._batch_polylines_mask is None:
+            polyline_info, self._batch_polylines, self._batch_polylines_mask = self._preprocess_polyline(
+                static_map=self._awml_static_map, target_state=current_ego, num_target=1, batch_polylines=None, batch_polylines_mask=None)
+        else:
+            polyline_info, _, __ = self._preprocess_polyline(
+                static_map=self._awml_static_map, target_state=current_ego, num_target=1, batch_polylines=self._batch_polylines, batch_polylines_mask=self._batch_polylines_mask)
 
-        polyline_info = self._preprocess_polyline(
-            static_map=self._awml_static_map, target_state=current_ego, num_target=1)
         sorted_histories = order_from_closest_to_furthest(
             current_ego, self._history.histories.values())
         relative_histories = get_relative_histories(

--- a/src/mtr_node.py
+++ b/src/mtr_node.py
@@ -49,6 +49,7 @@ from typing import List
 from typing_extensions import Self
 from dataclasses import dataclass
 import random
+import time
 
 
 def softmax(x: NDArray, axis: int) -> NDArray:
@@ -208,6 +209,7 @@ class MTRNode(Node):
         self._history.update(states, infos)
 
     def _callback(self, msg: Odometry) -> None:
+        start = time.perf_counter()
         # remove invalid ancient agent history
         timestamp = timestamp2ms(msg.header)
         self._history.remove_invalid(timestamp, self._timestamp_threshold)
@@ -262,6 +264,8 @@ class MTRNode(Node):
             score_threshold=self._score_threshold,
         )
         self._publisher.publish(pred_objs)
+        end = time.perf_counter()
+        print(f"Time taken: {end - start} seconds")
 
     def _postprocess(
         self,

--- a/src/mtr_node.py
+++ b/src/mtr_node.py
@@ -209,7 +209,6 @@ class MTRNode(Node):
         self._history.update(states, infos)
 
     def _callback(self, msg: Odometry) -> None:
-        start = time.perf_counter()
         # remove invalid ancient agent history
         timestamp = timestamp2ms(msg.header)
         self._history.remove_invalid(timestamp, self._timestamp_threshold)
@@ -264,8 +263,6 @@ class MTRNode(Node):
             score_threshold=self._score_threshold,
         )
         self._publisher.publish(pred_objs)
-        end = time.perf_counter()
-        print(f"Time taken: {end - start} seconds")
 
     def _postprocess(
         self,

--- a/utils/polyline.py
+++ b/utils/polyline.py
@@ -170,17 +170,11 @@ class TargetCentricPolyline:
         """
 
         if batch_polylines is None or batch_polylines_mask is None:
-            start = time.perf_counter()
-
             all_polylines: NDArrayF32 = static_map.get_all_polyline(as_array=True, full=True)
-            print(f"generate all polylines: {time.perf_counter() - start}")
-
-            start = time.perf_counter()
             batch_polylines, batch_polylines_mask = self._generate_batch(all_polylines)
-            print(f"generate batch time: {time.perf_counter() - start}")
+
         ret_polylines: NDArrayF32
         ret_polylines_mask: NDArrayBool
-        start = time.perf_counter()
         if len(batch_polylines) > self.num_polylines:
             polyline_center: NDArrayF32 = batch_polylines[..., :2].sum(axis=1) / np.clip(
                 batch_polylines_mask.sum(axis=-1, dtype=np.float32)[:, None],
@@ -205,11 +199,8 @@ class TargetCentricPolyline:
         else:
             ret_polylines = batch_polylines[None, ...].repeat(num_target, axis=0)
             ret_polylines_mask = batch_polylines_mask[None, ...].repeat(num_target, axis=0)
-        print(f"select topk time: {time.perf_counter() - start}")
-        start = time.perf_counter()
         ret_polylines, ret_polylines_mask = self._do_transform(
             ret_polylines, ret_polylines_mask, target_state, num_target)
-        print(f"do transform time: {time.perf_counter() - start}")
         info: dict = {}
         info["polylines"] = ret_polylines
         info["polylines_mask"] = ret_polylines_mask > 0


### PR DESCRIPTION
When calculating polylines we perform a costly operation to get batch polylines and batch polyline mask. But this operation can easily be done a single time and then stored to disk for further reuse (it does not depend on target or agent movements). As a result of this PR the main bottleneck of the node is fixed and the node can run at around 20 Hz in simulation: 

![image](https://github.com/user-attachments/assets/770f3fa8-1ea2-4df7-86ae-1acab8495886)
