### PR TITLE
fix: only generate single generator_info

### DIFF
--- a/autoware_mtr/conversion/trajectory.py
+++ b/autoware_mtr/conversion/trajectory.py
@@ -87,9 +87,8 @@ def to_trajectories(header: Header,
         header, info, cur_scores, cur_trajs, score_threshold, generator_uuid)
     generator_name: String = String()
     generator_name.data = "mtr"
-    generator_info = TrajectoryGeneratorInfo(
-        generator_id=generator_uuid, generator_name=generator_name)
-    output.generator_info = [generator_info for _ in range(len(output.trajectories))]
+    output.generator_info = [TrajectoryGeneratorInfo(
+        generator_id=generator_uuid, generator_name=generator_name)]
 
     return output
 


### PR DESCRIPTION
## Description
Currently the array size of `generator_info` field inside  [Trajectories.msg](https://github.com/tier4/new_planning_framework/blob/main/autoware_new_planning_msgs/msg/Trajectories.msg) is 6 (amount of trajectories generated).
However all trajectories are generated from MTR, so a single generator info would be fine.
With the uuid in generator info and uuid in trajectories, it will be able to find the corresponding trajectory.

## How it was tested
Checking the raw message information on lichtblick.
Before:
![Screenshot from 2025-01-29 17-17-39](https://github.com/user-attachments/assets/c01ea925-b449-4d46-8342-1539407f39e0)
After:
![Screenshot from 2025-01-29 17-22-28](https://github.com/user-attachments/assets/29799a3f-2517-4738-99f8-ecf893761c9c)

