### PR TITLE
fix: add autoware prefix for lanelet2_extension

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -13,7 +13,7 @@
   <exec_depend>nav_msgs</exec_depend>
   <exec_depend>rclpy</exec_depend>
   <exec_depend>std_msgs</exec_depend>
-  <exec_depend>lanelet2_extension_python</exec_depend>
+  <exec_depend>autoware_lanelet2_extension_python</exec_depend>
 
   <test_depend>ament_copyright</test_depend>
   <test_depend>ament_flake8</test_depend>


### PR DESCRIPTION
## How it was tested
`rosdep install -y --from-paths src --ignore-src --rosdistro $ROS_DISTRO`

### Before
```
ERROR: the following packages/stacks could not have their rosdep keys resolved
to system dependencies:
autoware_mtr_python: Cannot locate rosdep definition for [lanelet2_extension_python]
```
### After
```
#All required rosdeps installed successfully
```