### PR TITLE
use map path parameter

### DIFF
--- a/launch/mtr_ego_python.launch.xml
+++ b/launch/mtr_ego_python.launch.xml
@@ -11,7 +11,7 @@
   <arg name="output/trajectories" default="mtr/trajectories"/>
 
 
-  <arg name="lanelet_file" default="$(find-pkg-share autoware_mtr_python)/data/odaiba.lanelet2_map.osm"/>
+  <arg name="lanelet_file" default="$(var map_path)/lanelet2_map.osm"/>
   <arg name="intention_point_file" default="$(find-pkg-share autoware_mtr_python)/data/cluster64_dict.pkl"/>
   <arg name="build_only" default="false"/>
 

--- a/launch/mtr_ego_python.launch.xml
+++ b/launch/mtr_ego_python.launch.xml
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <launch>
+  <arg name="map_path" description="point cloud and lanelet2 map directory path"/>
+  
   <arg name="param_path" default="$(find-pkg-share autoware_mtr_python)/config/mtr_ego_node.param.yaml"/>
   <arg name="data_path" default="$(find-pkg-share autoware_mtr_python)/data"/>
 


### PR DESCRIPTION
## Description
The new planning framework is launched by the [new_planning_framework](https://github.com/tier4/new_planning_framework/blob/main/autoware_new_planning_launch/launch/new_planning.launch.xml).
The map_path parameter could be passed to the `mtr_ego_python.launch.xml`. 
It assumes that the osm file name is lanelet2_map.osm inside the directory.

## How it was tested
MTR node did not die in PSim. 
Checked with https://github.com/tier4/new_planning_framework/tree/feat/launch_map_path
![image](https://github.com/user-attachments/assets/84735504-6622-4bef-a394-c315fdacbb6b)
